### PR TITLE
Make it cross-platform, add options, new behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,20 +17,73 @@ const Paginator = require('./paginatorNonInfinite');
 
 
 class FileTreeSelectionPrompt extends Base {
-	
-	
-	getDirectoryContents(path=this.currentDirectory){
-		const dirContents = fs.readdirSync(path);
-		const mapped = dirContents.map(item => {
-			const fullPath = path + '\\' + item;
-			return fs.lstatSync(fullPath).isDirectory() ? 
-				{fullPath: fullPath, isDirectory: true, displayString: figures.pointer + ' ' + item} : 
-				{fullPath: fullPath, isDirectory: false, displayString: item};
+	static get EMPTY_OPTION_TEXT() {
+		return '<none>'
+	}
+
+	static get EMPTY_OPTION_ID() {
+		return -1
+	}
+
+	static get PARENT_DIR_TEXT() {
+		return path.join('..', '/')
+	}
+
+	static get PARENT_DIR_ID() {
+		return -2
+	}
+
+	static get CURR_DIR_TEXT() {
+		return path.join('.', '/')
+	}
+
+	static get CURR_DIR_ID() {
+		return -3
+	}
+
+
+	getDirectoryContents(dirPath=this.currentDirectory){
+		const dirContents = fs.readdirSync(dirPath);
+		const mapped = dirContents.map((item, index) => {
+			const fullPath = path.join(dirPath, item);
+			let result = {id: index, fullPath: fullPath}
+			if (fs.lstatSync(fullPath).isDirectory()) {
+				result = {...result, isDirectory: true, displayString: figures.pointer + ' ' + item};
+			} else {
+				result = {...result, isDirectory: false, displayString: item};
+			}
+			return result;
 		});
-		const sorted =[...mapped.filter(item => item.isDirectory), ...mapped.filter(item => !item.isDirectory)];
+		let sorted =[...mapped.filter(item => item.isDirectory), ...mapped.filter(item => !item.isDirectory)];
+
+		const parentDir = path.resolve(dirPath, '..')
+		if (parentDir !== dirPath) {
+			sorted = [{
+				id: this.constructor.PARENT_DIR_ID,
+				fullPath: path.resolve(parentDir),
+				isDirectory: true,
+				displayString: this.constructor.PARENT_DIR_TEXT
+			}, ...sorted]
+		}
+
+		sorted = [{
+			id: this.constructor.CURR_DIR_ID,
+			fullPath: dirPath,
+			isDirectory: true,
+			displayString: this.constructor.CURR_DIR_TEXT
+		}, ...sorted]
+
+		if (this.opt.allowNoneOption) {
+			sorted = [{
+				id: this.constructor.EMPTY_OPTION_ID,
+				fullPath: '',
+				isNone: true,
+				displayString: this.constructor.EMPTY_OPTION_TEXT
+			}, ...sorted]
+		}
 		return sorted;
 	}
-	
+
 	constructor(questions, rl, answers) {
 		super(questions, rl, answers);
 
@@ -42,20 +95,22 @@ class FileTreeSelectionPrompt extends Base {
 
 		this.opt = {
 			...{
-			  path: null,
-			  pageSize: 10 ,
-			  onlyShowMatchingExtensions: false,
-			  selectionType: 'file',
-			  extensions: [],
+				path: null,
+				pageSize: 10 ,
+				allowNoneOption: false,
+				onlyShowMatchingExtensions: false,
+				selectionType: 'file',
+				extensions: [],
 			},
 			...this.opt
-		  }
+			}
 
 		// Make sure no default is set (so it won't be printed)
 		this.opt.default = null;
 		this.opt.pageSize = 10;
 
 		this.paginator = new Paginator(this.screen);
+		this.history = []
 	}
 
 	/**
@@ -82,8 +137,14 @@ class FileTreeSelectionPrompt extends Base {
 		.pipe(takeWhile(() => this.status !== 'answered'))
 		.pipe(filter(key => key.key.name === 'escape'))
 		.forEach(this.onEscKey.bind(this));
-		
-
+		events.keypress
+		.pipe(takeWhile(() => this.status !== 'answered'))
+		.pipe(filter(key => key.key.name === 'right'))
+		.forEach(this.onRightKey.bind(this));
+		events.keypress
+		.pipe(takeWhile(() => this.status !== 'answered'))
+		.pipe(filter(key => key.key.name === 'left'))
+		.forEach(this.onLeftKey.bind(this));
 
 
 		events.line
@@ -99,31 +160,34 @@ class FileTreeSelectionPrompt extends Base {
 
 	}
 
-	renderNewDirectory(path){
-		this.currentDirectory = path
+	renderNewDirectory(dirPath){
+	  if (this.currentDirectory !== dirPath) {
+			this.history.push(this.currentDirectory)
+		}
+		this.currentDirectory = dirPath
 		this.directoryContents = this.getDirectoryContents()
 		this.shownList = this.getShownList()
-		this.selected = this.directoryContents.find(directoryItem => directoryItem.displayString === this.shownList[0])
+		this.selected = this.shownList.length ? this.shownList[0] : undefined
 		this.invalidSelection = false;
 		this.renderCurrentDirectory()
 	}
 
-	
+
 
 	getShownList(){
-		let shownList = undefined
+		let shownList
 		if(this.opt.onlyShowMatchingExtensions){
 			shownList = this.directoryContents.filter(directoryItem => {
-				return this.opt.extensions.some(extension => {
-					return directoryItem.displayString.endsWith(extension)
-				}) || directoryItem.isDirectory
+				return directoryItem.isDirectory || directoryItem.isNone || this.opt.extensions.some(extension => {
+					return directoryItem.fullPath.endsWith(extension)
+				})
 			})
 		}
 		else{
-			shownList = this.directoryContents
+			shownList = [...this.directoryContents]
 		}
 
-		return shownList.map(item => item.displayString)
+		return shownList
 	}
 
 	/**
@@ -134,13 +198,13 @@ class FileTreeSelectionPrompt extends Base {
 	renderCurrentDirectory() {
 		// Render question
 		let message = this.getQuestion();
-		
+
 
 		if (this.firstRender) {
 			this.firstRender = false;
 		}
 
-		
+
 
 		if (this.status === 'answered') {
 			message += chalk.cyan(this.selected.fullPath);
@@ -150,8 +214,11 @@ class FileTreeSelectionPrompt extends Base {
 			if(this.invalidSelection){
 				message+='\n' + chalk.red("Invalid selection. Please choose another option.") +'\n';
 			}
-			const directoryString = this.convertDirectoryContentToString();
-			message += '\n' + this.paginator.paginate(directoryString + '\n \n\n', this.shownList.indexOf(this.selected.displayString), this.opt.pageSize);
+			const directoryString = this.convertDirectoryContentToString(this.shownList);
+			const selectedIndex = this.selected ?
+					this.shownList.findIndex(directoryItem => directoryItem.id === this.selected.id) : undefined;
+			message += '\n' + this.paginator.paginate(directoryString + '\n \n\n',
+					selectedIndex, this.opt.pageSize);
 		}
 
 		this.screen.render(message);
@@ -161,16 +228,16 @@ class FileTreeSelectionPrompt extends Base {
 		let output = '';
 
 		directoryContents.forEach(directoryItem => {
-			if (directoryItem.displayString === this.selected.displayString) {
-				if(this.checkValidExtension(this.selected.displayString) || this.selected.isDirectory){
+			if (directoryItem.id === this.selected.id) {
+				if(this.selected.isNone || this.selected.isDirectory || this.checkValidExtension(this.selected.displayString)){
 					output += '\n' + chalk.hex('#0598BC')(directoryItem.displayString);
 				}
 				else{
 					output += '\n' + chalk.hex('#8dabb3')(directoryItem.displayString);
+				}
 			}
-		}
 			else {
-				if(this.checkValidExtension(directoryItem.displayString) || directoryItem.isDirectory){
+				if(this.isNone || this.isDirectory || this.checkValidExtension(directoryItem.displayString)){
 				output += '\n' +  directoryItem.displayString;
 			}
 			else{
@@ -194,7 +261,7 @@ class FileTreeSelectionPrompt extends Base {
 			return;
 		}
 		else{
-	  
+
 			this.status = 'answered';
 
 			this.renderCurrentDirectory();
@@ -204,16 +271,19 @@ class FileTreeSelectionPrompt extends Base {
 			this.done(this.selected.fullPath);
 		}
 	}
-		
-	
+
+
 
 	checkValidSelection(){
 		if(this.selected.isDirectory){
 			return this.opt.selectionType === 'folder'
 		}
+		else if (this.selected.isNone) {
+			return true
+		}
 		else {
 			return this.opt.selectionType === 'file' && this.checkValidExtension(this.selected.displayString)
-			
+
 		}
 	}
 
@@ -224,7 +294,7 @@ class FileTreeSelectionPrompt extends Base {
 }
 
 	moveSelected(distance = 0) {
-		const currentIndex = this.shownList.indexOf(this.selected.displayString);
+		const currentIndex = this.shownList.findIndex(directoryItem => directoryItem.id === this.selected.id);
 		let index = currentIndex + distance;
 		if (index >= this.shownList.length) {
 			index = this.shownList.length - 1;
@@ -233,7 +303,7 @@ class FileTreeSelectionPrompt extends Base {
 			index = 0;
 		}
 
-		this.selected = this.directoryContents.find(item => item.displayString === this.shownList[index]);
+		this.selected = this.shownList.length ? this.shownList[index] : undefined
 
 		this.renderCurrentDirectory();
 	}
@@ -249,23 +319,33 @@ class FileTreeSelectionPrompt extends Base {
 		this.moveSelected(1);
 	}
 
-	onSpaceKey() {
-		if (!this.selected.isDirectory) {
-			return;
-		}
-		this.renderNewDirectory(this.selected.fullPath);
+	onLeftKey() {
+		return this.onEscKey()
 	}
+
+	onRightKey() {
+		if (this.selected && this.selected.isDirectory && this.selected.id !== this.constructor.CURR_DIR_ID &&
+				this.selected.id !== this.constructor.PARENT_DIR_ID) {
+			return this.onSpaceKey()
+		} else if (this.history.length) {
+		  const dirPath = this.history.pop()
+			this.renderNewDirectory(dirPath)
+			this.history.pop()
+		}
+	}
+
 	onSpaceKey() {
-		if (!this.selected.isDirectory) {
+		if (!this.selected || !this.selected.isDirectory || this.selected.id === this.constructor.CURR_DIR_ID) {
 			return;
 		}
 		this.renderNewDirectory(this.selected.fullPath);
 	}
 
 	onEscKey(){
-		const splCurrentDirectory = this.currentDirectory.split('\\')
-		splCurrentDirectory.pop()
-		this.renderNewDirectory(splCurrentDirectory.join('\\'))
+		const parentDir = path.resolve(this.currentDirectory, '..')
+		if (parentDir !== this.currentDirectory) {
+			this.renderNewDirectory(parentDir)
+		}
 	}
 
 }

--- a/paginatorNonInfinite.js
+++ b/paginatorNonInfinite.js
@@ -19,17 +19,17 @@ class Paginator {
 	paginate(output, active, pageSize) {
 		pageSize = pageSize || 7;
 		var lines = output.split('\n');
-    
+
 		this.pointer += active - this.oldActive;
 		this.oldActive=active;
 
-    
+
 
 		if (this.screen) {
 			lines = this.screen.breakLines(lines);
 			lines = _.flatten(lines);
 		}
-    
+
 
 		// Make sure there's enough lines to paginate
 		if (lines.length <= pageSize) {
@@ -43,11 +43,11 @@ class Paginator {
 		this.lastIndex = Math.min(lines.length, firstIndex + pageSize);
 
 		// Duplicate the lines so it give an infinite list look
-		var infinite = _.flatten([lines]);    
+		var infinite = _.flatten([lines]);
 
 		var section = infinite.splice(firstIndex, pageSize).join('\n');
-		section += '\n' + chalk.dim('========================================================================================'); 
-		return section + '\n' + chalk.dim('(Press up and down to navigate, space to enter directory, esc to go to parent directory)');
+		section += '\n' + chalk.dim('========================================================================================');
+		return section + '\n' + chalk.dim('(Press up and down to navigate, space/right to enter directory, left/esc to go to parent directory, right to go back through history)');
 	}
 }
 


### PR DESCRIPTION
* make it cross-platform using the os-specific slashes
* allow option to be able to select `<none>` (no file)
* add a way to navigate history (last directory you were at)
* add `./` option to be able to select current directory
* add `../` option as a convenience to go up to parent directory
* add left arrow key to navigate to parent directory
* add right arrow key to navigate into directory or backward in history (depending on the context)